### PR TITLE
Exposing prometheus metrics

### DIFF
--- a/cmd/tagger/main.go
+++ b/cmd/tagger/main.go
@@ -75,6 +75,7 @@ func main() {
 	qyctrl := controllers.NewQuayWebHook(tagsvc)
 	dkctrl := controllers.NewDockerWebHook(tagsvc)
 	dpctrl := controllers.NewDeployment(corinf, depsvc)
+	moctrl := controllers.NewMetric()
 
 	// starts up all informers and waits for their cache to sync
 	// up, only then we start the operators i.e. start to process
@@ -95,7 +96,7 @@ func main() {
 	klog.Info("caches in sync, moving on.")
 
 	var wg sync.WaitGroup
-	ctrls := []Controller{mtctrl, qyctrl, dkctrl, dpctrl, itctrl}
+	ctrls := []Controller{mtctrl, qyctrl, dkctrl, dpctrl, itctrl, moctrl}
 	for _, ctrl := range ctrls {
 		wg.Add(1)
 		go func(c Controller) {

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -1,0 +1,54 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Metric is our controller for metric requests. Spawns an http metric and
+// exposes all metrics registered on prometheus.
+type Metric struct {
+	bind string
+}
+
+// NewMetric returns a new metric controller.
+func NewMetric() *Metric {
+	return &Metric{
+		bind: ":8090",
+	}
+}
+
+// Name returns a name identifier for this controller.
+func (m *Metric) Name() string {
+	return "metrics http server"
+}
+
+// Start puts the metrics http server online.
+func (m *Metric) Start(ctx context.Context) error {
+	server := &http.Server{
+		Addr:    m.bind,
+		Handler: promhttp.Handler(),
+	}
+
+	go func() {
+		<-ctx.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			klog.Errorf("error shutting down https server: %s", err)
+		}
+	}()
+
+	if err := server.ListenAndServe(); err != nil {
+		if err == http.ErrServerClosed {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/containers/image/v5 v5.6.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24
+	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v1.0.0
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	gopkg.in/yaml.v2 v2.3.0

--- a/manifests/03_deploy.yaml
+++ b/manifests/03_deploy.yaml
@@ -72,3 +72,16 @@ spec:
     - protocol: TCP
       port: 8082 
       targetPort: 8082
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics
+  namespace: tagger
+spec:
+  selector:
+    app: tagger
+  ports:
+    - protocol: TCP
+      port: 8090
+      targetPort: 8090

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -150,6 +150,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.1.0
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp


### PR DESCRIPTION
This commit adds a new controller listening to requests on port 8090 and
exposing prometheus metrics through it.

Metrics are coming in a next PR through a service.