### PR TITLE
Using Fedora for Build and Execution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+_output/
+.env
+.git/
+.gitignore
+.vscode/
+assets/
+README.md
+LICENSE

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,22 @@
+---
+name: image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  docker:
+    name: docker-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out code
+        uses: actions/checkout@v2
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          tags: quay.io/rmarasch/tagger:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,26 @@
 # Builder
 #
 
-FROM registry.fedoraproject.org/fedora:latest AS builder
+FROM docker.io/fedora:latest AS builder
 
-WORKDIR /src
-COPY . .
+RUN dnf install -y fedora-repos-rawhide && \
+    dnf install -y --nogpgcheck --allowerasing --enablerepo=rawhide golang
 
 RUN dnf install -y \
     btrfs-progs-devel \
     device-mapper-devel \
-    golang \
     gpgme-devel \
     make
 
+WORKDIR /src
+COPY . .
 RUN make
 
 #
 # Application
 #
 
-FROM registry.fedoraproject.org/fedora:latest
+FROM docker.io/fedora:latest
 
 COPY --from=builder /src/_output/bin/tagger /usr/local/bin/tagger
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,34 @@
-FROM docker.io/library/golang:1.15.3-buster AS builder
-RUN apt-get update -y
-RUN apt-get install -y libgpgme-dev libbtrfs-dev libdevmapper-dev
-WORKDIR /go/src/tagger
+#
+# Builder
+#
+
+FROM registry.fedoraproject.org/fedora:latest AS builder
+
+WORKDIR /src
 COPY . .
-RUN make build
 
+RUN dnf install -y \
+    btrfs-progs-devel \
+    device-mapper-devel \
+    golang \
+    gpgme-devel \
+    make
 
-FROM registry.centos.org/centos:8
-WORKDIR /
+RUN make
+
+#
+# Application
+#
+
+FROM registry.fedoraproject.org/fedora:latest
+
+COPY --from=builder /src/_output/bin/tagger /usr/local/bin/tagger
+
 # 8080 pod mutating webhook handler.
 # 8081 quay webhooks handler.
 # 8082 docker webhooks handler.
 # 8083 tags export/import handler.
 # 8090 metrics endpoint.
 EXPOSE 8080 8081 8082 8083 8090
-COPY --from=builder /go/src/tagger/_output/bin/tagger /usr/local/bin/
-CMD "/usr/local/bin/tagger"
+
+ENTRYPOINT [ "/usr/local/bin/tagger" ]

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,62 @@
-.PHONY: get-code-generator generate build clean
+APP = tagger
+PLUGIN = kubectl-tag
 
-PROJECT=github.com/ricardomaraschini/tagger
-GEN_OUTPUT=/tmp/$(PROJECT)/infra/tags
+IMAGE_BUILDER ?= podman
+IMAGE ?= quay.io/rmarasch/tagger
+IMAGE_TAG = $(IMAGE):latest
 
-build:
-	go build -mod vendor -o _output/bin/tagger ./cmd/tagger
-	go build -mod vendor -o _output/bin/kubectl-tag ./cmd/kubectl-tag
+OUTPUT_DIR ?= _output
+OUTPUT_BIN = $(OUTPUT_DIR)/bin
 
+TAGGER_BIN = $(OUTPUT_BIN)/$(APP)
+PLUGIN_BIN = $(OUTPUT_BIN)/$(PLUGIN)
+GEN_BIN = $(OUTPUT_DIR)/code-generator
+
+PROJECT = github.com/ricardomaraschini/$(APP)
+GEN_OUTPUT = /tmp/$(PROJECT)/infra/tags
+
+default: build
+
+build: $(APP) $(PLUGIN)
+
+.PHONY: $(APP)
+$(APP):
+	go build -o $(TAGGER_BIN) ./cmd/$(APP)
+
+.PHONY: $(PLUGIN)
+$(PLUGIN):
+	go build -o $(PLUGIN_BIN) ./cmd/$(PLUGIN)
+
+.PHONY: get-code-generator
 get-code-generator:
-	rm -rf _output/code-generator
-	git clone --depth=1                                                     \
-		https://github.com/kubernetes/code-generator.git                \
-		_output/code-generator
+	rm -rf $(GEN_BIN) || true
+	git clone --depth=1 \
+		https://github.com/kubernetes/code-generator.git \
+		$(GEN_BIN)
 
+generate: generate-proto generate-k8s
+
+.PHONY: generate-proto
 generate-proto:
-	protoc --go-grpc_out=paths=source_relative:.				\
-		--go_out=paths=source_relative:.				\
+	protoc --go-grpc_out=paths=source_relative:. \
+		--go_out=paths=source_relative:. \
 		./infra/pb/*.proto
 
+.PHONY: generate-k8s
 generate-k8s:
-	_output/code-generator/generate-groups.sh all                           \
-		$(PROJECT)/infra/tags/v1/gen					\
-		$(PROJECT)                                                      \
-		infra/tags:v1                                                   \
-		--go-header-file _output/code-generator/hack/boilerplate.go.txt \
+	rm -rf $(GEN_OUTPUT) || true
+	$(GEN_BIN)/generate-groups.sh all \
+		$(PROJECT)/infra/tags/v1/gen \
+		$(PROJECT) \
+		infra/tags:v1 \
+		--go-header-file=$(GEN_BIN)/hack/boilerplate.go.txt \
 		--output-base=/tmp
 	rm -rf infra/tags/v1/gen
 	mv $(GEN_OUTPUT)/v1/* infra/tags/v1/
 
 image:
-	podman build -t quay.io/rmarasch/tagger .
+	$(IMAGE_BUILDER) build --tag=$(IMAGE_TAG) .
 
+.PHONY: clean
 clean:
 	rm -rf _output


### PR DESCRIPTION
- Changing default platform for `Dockerfile` to use Fedora on building and running;
- Adding variables on  `Makefile` to run targets in a different context, like in my current fork;
- Adding a GitHub Action to simulate container image build;