### PR TITLE
Allow Tagger to use only on registry repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,14 @@ things such as authentication thus should not be used in production. Tagger can 
 of the mirror registry location through a Secret called `mirror-registry-config`, this secret may
 contain the following properties:
 
-
-| Name     | Description                                                                         |
-| ---------| ----------------------------------------------------------------------------------- |
-| address  | The mirror registry URL                                                             |
-| username | Username Tagger should use when accessing the mirror registry                       |
-| password | The password to be used by Tagger                                                   |
-| token    | The auth token to be used by Tagger (optional)                                      |
-| insecure | Allows Tagger to access insecure registry if set to "true" (string)                 |
+| Name       | Description                                                                       |
+| -----------| --------------------------------------------------------------------------------- |
+| address    | The mirror registry URL                                                           |
+| username   | Username Tagger should use when accessing the mirror registry                     |
+| password   | The password to be used by Tagger                                                 |
+| token      | The auth token to be used by Tagger (optional)                                    |
+| insecure   | Allows Tagger to access insecure registry if set to "true" (string)               |
+| repository | If set Tagger will mirror all images inside the same Registry repository          |
 
 Follow below an example of a `mirror-registry-config` Secret:
 

--- a/infra/images/v1beta1/types.go
+++ b/infra/images/v1beta1/types.go
@@ -107,7 +107,7 @@ type ImageSpec struct {
 
 // ImageStatus is the current status for an image tag.
 type ImageStatus struct {
-	HashReferences []HashReference `json:"hashReferences"`
+	HashReferences []HashReference `json:"hashReferences,omitempty"`
 }
 
 // ImportAttempt holds data about an import cycle. Keeps track if it

--- a/infra/imagestore/registry.go
+++ b/infra/imagestore/registry.go
@@ -28,54 +28,58 @@ import (
 	"github.com/ricardomaraschini/tagger/infra/fs"
 )
 
-// CleanFn is a function that must be called in order to clean up or
-// free resources in use.
+// CleanFn is a function that must be called in order to clean up or free resources in use.
 type CleanFn func()
 
-// Registry wraps calls for iteracting with our backend registry. It
-// provides an implementation capable of pushing to and pulling from
-// an image registry. To push an image towards the registry one needs
-// to call Load, to push it to a local tar file a Save call should be
-// made, this strange naming is an attempt to make it similar to the
-// 'docker save/load' commands.
+// Registry wraps calls for iteracting with our backend registry. It provides an implementation
+// capable of pushing to and pulling from an image registry. To push an image towards the
+// registry one needs to call Load, to push it to a local tar file a Save call should be made,
+// this strange naming is an attempt to make it similar to the 'docker save/load' commands.
 type Registry struct {
-	fs      *fs.FS
-	regaddr string
-	polctx  *signature.PolicyContext
-	regctx  *types.SystemContext
+	fs         *fs.FS
+	regaddr    string
+	repository string
+	polctx     *signature.PolicyContext
+	regctx     *types.SystemContext
 }
 
-// NewRegistry creates an entity capable of load objects to or save
-// objects from a backend registry. When calling Load we push an image
-// into the registry, when calling Save we pull the image from the
-// registry and store into a local tar file (format in disk is of type
-// docker-archive, we should migrate this to something else as it does
-// not support manifest lists).
+// NewRegistry creates an entity capable of load objects to or save objects from a backend
+// registry. When calling Load we push an image into the registry, when calling Save we pull
+// the image from the registry and store into a local tar file (format in disk is of type
+// docker-archive, we should migrate this to something else as it does not support manifest
+// lists).
 func NewRegistry(
 	regaddr string,
+	repository string,
 	sysctx *types.SystemContext,
 	polctx *signature.PolicyContext,
 ) *Registry {
 	return &Registry{
-		fs:      fs.New(),
-		regaddr: regaddr,
-		polctx:  polctx,
-		regctx:  sysctx,
+		fs:         fs.New(),
+		regaddr:    regaddr,
+		polctx:     polctx,
+		regctx:     sysctx,
+		repository: repository,
 	}
 }
 
-// Load pushes an image reference into the backend registry using repo/name
-// as its destination. Uses srcctx (of type types.SystemContext) when reading
-// image from srcref, so when copying from one remote registry into our mirror
-// registry srcctx must contain all needed authentication information.
+// Load pushes an image reference into the backend registry. Uses srcctx (types.SystemContext)
+// when reading image from srcref, so when copying from one remote registry into our mirror
+// registry srcctx must contain all needed authentication information. Images may be stored in
+// mirror.registry.io/namespace/name or mirror.registry.io/repository/namespace-name.
 func (i *Registry) Load(
 	ctx context.Context,
 	srcref types.ImageReference,
 	srcctx *types.SystemContext,
-	repo string,
+	ns string,
 	name string,
 ) (types.ImageReference, error) {
-	tostr := fmt.Sprintf("docker://%s/%s/%s", i.regaddr, repo, name)
+
+	tostr := fmt.Sprintf("docker://%s/%s/%s", i.regaddr, ns, name)
+	if len(i.repository) > 0 {
+		tostr = fmt.Sprintf("docker://%s/%s/%s-%s", i.regaddr, i.repository, ns, name)
+	}
+
 	toref, err := alltransports.ParseImageName(tostr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid destination reference: %w", err)


### PR DESCRIPTION
With this patch Tagger can now use only one registry repository to store
all mirrored images.

Prior to this patch images were mirrored to something like:

mirror.registry.io/namespace/imagename

Now users can also opt in to mirror images in the following URL:

mirror.registry.io/repository/namespace-imagename

The property "repository" is configurable through the mirror config
secret.