### PR TITLE
Auto pruning ImageImport objects

### DIFF
--- a/services/imageimport_test.go
+++ b/services/imageimport_test.go
@@ -108,7 +108,7 @@ func TestImageImportSync(t *testing.T) {
 		},
 		{
 			name:    "empty target img",
-			err:     "image import without target image",
+			err:     "empty spec.targetImage",
 			succeed: false,
 			timp: &imgv1b1.ImageImport{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
ImageImports live for one hour after they are indexed in an Image. If
they are in a faulty state (no more retries) it is also collected after
one hour.