### PR TITLE
chore: enable load balancer during ci

### DIFF
--- a/.github/workflows/etc/kind-cluster.yaml
+++ b/.github/workflows/etc/kind-cluster.yaml
@@ -1,0 +1,10 @@
+# This is the default kind cluster configuration used in the CI/CD pipeline.
+# Be aware that there will be a limit on how far we can stretch this. For the
+# basic functionality tests it should be more than enough.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/.github/workflows/etc/metallb.yaml
+++ b/.github/workflows/etc/metallb.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: pool
+  namespace: metallb
+spec:
+  addresses:
+  - 172.18.100.244-172.18.100.254
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: advertisement
+  namespace: metallb

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -90,10 +90,31 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
 
+    # we need to control the ip addresses used so we can properly deploy
+    # the metal lb later on so we pre-create the kind network. for the
+    # tests purpose this network does not need to be very large.
+    - name: Create the kind network
+      run: |-
+        docker network create \
+          --gateway "172.18.100.1" \
+          --scope "local" \
+          --driver "bridge" \
+          --subnet "172.18.100.0/24" \
+          --ipv4 \
+          kind
+
     - name: Install kind
       uses: helm/kind-action@v1
       with:
+        config: .github/workflows/etc/kind-cluster.yaml
         cluster_name: kind
+
+    - name: Install and configure metal load balancer
+      run: |-
+        kubectl create namespace metallb
+        helm repo add metallb https://metallb.github.io/metallb
+        helm install --debug --wait -n metallb metallb metallb/metallb
+        kubectl apply -f ./.github/workflows/etc/metallb.yaml
 
     - name: Build image
       id: push
@@ -123,7 +144,6 @@ jobs:
         helm install --debug --wait \
           --set image=quay.io/tagger/operator:pr-${{ github.event.number }} \
           --set imagePullPolicy=Never \
-          --set loadBalancer=false \
           tagger ./chart
 
     - name: Run integration tests


### PR DESCRIPTION
if we are going to test the kubectl-image plugin we need a load balancer service. this commit uses metal load balancer on top of the existing kind cluster.